### PR TITLE
Fix inconsistent settings keys

### DIFF
--- a/Patlat/AppDelegate.swift
+++ b/Patlat/AppDelegate.swift
@@ -9,29 +9,13 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    struct Settings {
-        static var isHapticEnabled: Bool {
-            get { UserDefaults.standard.bool(forKey: "hapticEnabled") }
-            set { UserDefaults.standard.set(newValue, forKey: "hapticEnabled") }
-        }
-        static var isSoundEnabled: Bool {
-            get { UserDefaults.standard.bool(forKey: "soundEnabled") }
-            set { UserDefaults.standard.set(newValue, forKey: "soundEnabled") }
-        }
-
-        // Uygulama ilk açıldığında varsayılan değerleri atamak için
-        static func registerDefaults() {
-            UserDefaults.standard.register(defaults: [
-                "hapticEnabled": true,
-                "soundEnabled": true
-            ])
-        }
-    }
 
     var window: UIWindow?
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Varsayılan kullanıcı ayarlarını kaydet
+        Settings.registerDefaults()
         // Override point for customization after application launch.
         return true
     }

--- a/Patlat/Settings.swift
+++ b/Patlat/Settings.swift
@@ -1,13 +1,25 @@
 import Foundation
 
 struct Settings {
-    static var isSoundEnabled: Bool {
-        get { UserDefaults.standard.object(forKey: "isSoundEnabled") as? Bool ?? true }
-        set { UserDefaults.standard.set(newValue, forKey: "isSoundEnabled") }
+    private static let soundKey = "soundEnabled"
+    private static let hapticKey = "hapticEnabled"
+
+    /// Uygulama ilk açıldığında varsayılan değerleri kaydeder.
+    static func registerDefaults() {
+        UserDefaults.standard.register(defaults: [
+            soundKey: true,
+            hapticKey: true
+        ])
     }
+
+    static var isSoundEnabled: Bool {
+        get { UserDefaults.standard.object(forKey: soundKey) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: soundKey) }
+    }
+
     static var isHapticEnabled: Bool {
-        get { UserDefaults.standard.object(forKey: "isHapticEnabled") as? Bool ?? true }
-        set { UserDefaults.standard.set(newValue, forKey: "isHapticEnabled") }
+        get { UserDefaults.standard.object(forKey: hapticKey) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: hapticKey) }
     }
 }
 //


### PR DESCRIPTION
## Summary
- unify settings storage keys
- remove duplicate `Settings` struct in `AppDelegate`
- register default preferences when the app launches

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584ed648048333bb9ed8a9603d66b6